### PR TITLE
add sway/workspaces css class name for active window

### DIFF
--- a/waybar/style.css
+++ b/waybar/style.css
@@ -22,6 +22,7 @@ window#waybar {
     text-shadow: inherit;
     background-image: linear-gradient(0deg, @selection, @background-darker);
 }
+#workspaces button.focused,
 #workspaces button.active {
     background-image: linear-gradient(0deg, @purple, @selection);
 }


### PR DESCRIPTION
Hey 👋 the styling looks great when using hyprland/workspaces but unfortunately sway/workspaces uses `#workspaces button.focused` instead of `#workspaces button.active`

Have a PR here that adds the required CSS to support both

sway/workspaces css classes -https://github.com/Alexays/Waybar/wiki/Module:-Sway#style-2
hyprland/workspaces css classes -https://github.com/Alexays/Waybar/wiki/Module:-Hyprland#style